### PR TITLE
Deselected confirmation checkbox.

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature-request.md
+++ b/.github/ISSUE_TEMPLATE/feature-request.md
@@ -15,9 +15,9 @@ assignees: ''
 
 
 
-**Before making this issue, replace the underscores in the following boxes with an `X` to confirm that you have acknowledged them.** *Failure to do so may result in your request being closed automatically.*
+**Before making this issue, replace the spaces in the following boxes with an `X` to confirm that you have acknowledged them.** *Failure to do so may result in your request being closed automatically.*
 
 
 
-1. [X] I have done a quick search in the list of suggestions to make sure this has not been suggested yet.
-2. [X] I am familiar with all the content already in the game or have glanced at the wiki to make sure my suggestion doesn't exist in the game yet.
+1. - [ ] I have done a quick search in the list of suggestions to make sure this has not been suggested yet.
+2. - [ ] I am familiar with all the content already in the game or have glanced at the wiki to make sure my suggestion doesn't exist in the game yet.


### PR DESCRIPTION
This checkbox was selected by default, meaning users could've submitted an issue without actually reading the statements.