### PR TITLE
Disable blank issues using config.yml

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: false


### PR DESCRIPTION
adds `blank_issues_enabled: false` which forces issues to use one of the selected templates.
Try and create an issue on [Katsute/Mindustry-Suggestions](https://github.com/Katsute/Mindustry-Suggestions) and you will see there is no longer an option to create a blank issue.