### PR TITLE
Fix typo and change boxes

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature-request.md
+++ b/.github/ISSUE_TEMPLATE/feature-request.md
@@ -15,10 +15,10 @@ assignees: ''
 
 
 
-**Before making this issue, replace the spaces in the following boxes with an `X` to confirm that you have acknowledged them.** *Failure to do so may result in your request being closed automatically.*
+**Before making this issue, place an `X` in the boxes below to confirm that you have acknowledged them.** *Failure to do so may result in your request being closed automatically.*
 
 
 
-1. - [ ] I have done a quick search in the list of suggestions to make sure this has not been suggested yet.
-2. - [ ] I have checked the [Trello](https://trello.com/b/aE2tcUwF/mindustry-trello) to make sure my suggestion isn't planned or implemented in a development version.
-3. - [ ] I am familiar with all the content already in the game or have glanced at the wiki to make sure my suggestion doesn't exist in the game yet.
+1. - [] I have done a quick search in the list of suggestions to make sure this has not been suggested yet.
+2. - [] I have checked the [Trello](https://trello.com/b/aE2tcUwF/mindustry-trello) to make sure my suggestion isn't planned or implemented in a development version.
+3. - [] I am familiar with all the content already in the game or have glanced at the wiki to make sure my suggestion doesn't exist in the game yet.

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # Mindustry-Suggestions
-This is the repository for Mindustry suggestions and feedback. 
+This is the repository for Mindustry suggestions and feedback.
 
 For bug reports, use the [Mindustry issue tracker](https://github.com/Anuken/Mindustry/issues/new/choose).
 
 ## How do I know if you've read my suggestion?
 
-If it's been 24 hours, I've most likely read it. I check this repository daily. If I like it, I'll implemented it.  
+If it's been 24 hours, I've most likely read it. I check this repository daily. If I like it, I'll implement it.  
 *However*, If your request is in a language I don't understand and clearly doesn't follow the template, I am unlikely to bother reading it.
 
 ## I will no longer be commenting or closing issues here.


### PR DESCRIPTION
I think it would be a good idea to remove the space from the boxes and just tell people to put an 'X' there instead of telling them to replace the space with an 'X' because many feature requests have the space and the 'X', which doesn't create a nice checked box. I think the typo is self-explanatory.