### PR TITLE
Add a checkbox to make sure people have read README.md

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature-request.md
+++ b/.github/ISSUE_TEMPLATE/feature-request.md
@@ -22,4 +22,4 @@ assignees: ''
 1. - [] I have done a quick search in the list of suggestions to make sure this has not been suggested yet.
 2. - [] I have checked the [Trello](https://trello.com/b/aE2tcUwF/mindustry-trello) to make sure my suggestion isn't planned or implemented in a development version.
 3. - [] I am familiar with all the content already in the game or have glanced at the wiki to make sure my suggestion doesn't exist in the game yet.
-4. - [ ] I have read `README.md` to make sure my idea is not listed under the "A few things you shouldn't suggest" category.
+4. - [] I have read `README.md` to make sure my idea is not listed under the "A few things you shouldn't suggest" category.

--- a/.github/ISSUE_TEMPLATE/feature-request.md
+++ b/.github/ISSUE_TEMPLATE/feature-request.md
@@ -19,7 +19,6 @@ assignees: ''
 
 
 
-
 1. - [] I have done a quick search in the list of suggestions to make sure this has not been suggested yet.
 2. - [] I have checked the [Trello](https://trello.com/b/aE2tcUwF/mindustry-trello) to make sure my suggestion isn't planned or implemented in a development version.
 3. - [] I am familiar with all the content already in the game or have glanced at the wiki to make sure my suggestion doesn't exist in the game yet.

--- a/.github/ISSUE_TEMPLATE/feature-request.md
+++ b/.github/ISSUE_TEMPLATE/feature-request.md
@@ -22,3 +22,4 @@ assignees: ''
 1. - [ ] I have done a quick search in the list of suggestions to make sure this has not been suggested yet.
 2. - [ ] I have checked the [Trello](https://trello.com/b/aE2tcUwF/mindustry-trello) to make sure my suggestion isn't planned or implemented in a development version.
 3. - [ ] I am familiar with all the content already in the game or have glanced at the wiki to make sure my suggestion doesn't exist in the game yet.
+4. - [ ] I have read `README.md` to make sure my idea is not listed under the "A few things you shouldn't suggest" category


### PR DESCRIPTION
Some people accidentally suggest things listed under the "A few things you shouldn't suggest" category; Maybe this will help prevent that. 

I am partially against the idea of having a 4th checkbox, but some people honestly forget and get ridiculed for not reading the `README.md`. 