### PR TITLE
Clarify "Additional configuration of blocks"

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,4 +25,4 @@ In very rare cases, I may ask for clarifications or start a general discussion o
 - Controller support
 - Turrets on top of cores, or similar "merged behavior" blocks like turrets with drills
 - Built-in cloud sync
-- Additional configuration of blocks (e.g. I/O side configuration, which has been suggested a million times)
+- Additional configuration of blocks, such as I/O side configuration, which has been suggested a million times


### PR DESCRIPTION
I, along with others, have gotten mixed up about the block config line. For a while I thought it was clarifying that I/O side config was what it was referring to, due to my eyes glancing over the "e.g." My request is to simply extend that "e.g." into two words to emphasize that things such as upgrades are also counted.