### PR TITLE
Do not name units.

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,3 +27,4 @@ In very rare cases, I may ask for clarifications or start a general discussion o
 - Built-in cloud sync
 - Additional configuration of blocks, such as I/O side configuration, which has been suggested a million times
 - Removing metaglass from the water extractor recipe
+- Naming Units that are already planned or already in the game.


### PR DESCRIPTION
Restrict suggestions that solely suggest unit names for already planned or existing units.