### PR TITLE
Update README.md - Add Reply Guidelines

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@ This is the repository for [Mindustry](https://github.com/Anuken/Mindustry) sugg
 
 For bug reports, use the [Mindustry issue tracker](https://github.com/Anuken/Mindustry/issues/new/choose).
 
+NOTE: Read the bottom category, as there is a new category: **"Replying Guidelines"**
+
 ## How do I know if you've read my suggestion?
 
 If it's been 24 hours, I've most likely read it. I check this repository daily. If I like it, I'll implement it.  
@@ -32,3 +34,13 @@ In very rare cases, I may ask for clarifications or start a general discussion o
 - Any sort of string manipulation in logic (reading from message blocks, reading characters, splitting strings, etc)
 - Allied teams
 - Bringing back overflow-sorter chaining
+
+## Replying Guidelines (>= 6/6/2022)
+##### All responses to topics beyond 6/6/2022 should follow these guidelines.
+
+1. Responses SHOULD be a follow-up of what you are replying to, and shouldn't derail the thread's topic or current point (unless required, like if a Topic Fire was active)
+2. Responses SHOULD be constructive if it is criticism. Both positive and negative is accepted, but intently bringing nothing to the topic other than bullcrap is not tolerated, and can easily get yourself voided from topics in terms of topic contribution
+3. Responses SHOULDN'T boycot topics or users. If you have nothing good to contribute, don't reply
+4. Responses SHOULDN'T be created with the intent and capability of causing a Topic Fire *(a scenario where the topic's purpose is voided over a heavy conflict between two or more contributors)*
+5. Responses SHOULD be respectful to other users
+6. Responses CAN appreciate the cat at all times *(when applicable)*.


### PR DESCRIPTION
I have been finding that some people are continuously devaluing suggestions for very niche reasons, and it's been going on for an estimate of two whole years. If you have suggested anything before, you would know one of them. The pull request simply adds a new category to the `README.md` file, which addresses the guidelines for how the good contributors of topics should respond.

It's obvious that there may need to be some more guidelines or alterations, but besides that, I think the addition of a Replying Guidelines category would help people understand what they should and shouldn't do. If the guidelines are reinforced, the few people who attempt to pull out nonconstructive feedback intently will likely end up stopping.